### PR TITLE
Add packages required for scrapy installation in intro notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*.ipynb_checkpoints

--- a/intro/Introduction to Python.ipynb
+++ b/intro/Introduction to Python.ipynb
@@ -247,7 +247,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "apt-get install -y -q libxslt-dev libxml2-dev\n",
+    "apt-get install -y -q libxslt-dev libxml2-dev libffi-dev libssl-dev\n",
     "pip install -q scrapy"
    ]
   }


### PR DESCRIPTION
Fixes #12 
I also added `.gitignore` to ignore the .ipynb_checkpoints files

Here is the output from `intro/Introduction to Python.ipynb`:

```
> %%bash
> apt-get install -y -q libxslt-dev libxml2-dev libffi-dev libssl-dev
> pip install -q scrapy

Reading package lists...
Building dependency tree...
Reading state information...
libxml2-dev is already the newest version.
The following extra packages will be installed:
  libssl-doc libxslt1.1
The following NEW packages will be installed:
  libffi-dev libssl-dev libssl-doc libxslt1-dev libxslt1.1
0 upgraded, 5 newly installed, 0 to remove and 0 not upgraded.
Need to get 3348 kB of archives.
After this operation, 11.6 MB of additional disk space will be used.
Get:1 http://security.debian.org/ jessie/updates/main libxslt1.1 amd64 1.1.28-2+deb8u1 [232 kB]
Get:2 http://httpredir.debian.org/debian/ jessie/main libffi-dev amd64 3.1-2+b2 [155 kB]
Get:3 http://httpredir.debian.org/debian/ jessie/main libssl-dev amd64 1.0.1t-1+deb8u2 [1282 kB]
Get:4 http://httpredir.debian.org/debian/ jessie/main libssl-doc all 1.0.1t-1+deb8u2 [1168 kB]
Get:5 http://security.debian.org/ jessie/updates/main libxslt1-dev amd64 1.1.28-2+deb8u1 [511 kB]
Fetched 3348 kB in 0s (3870 kB/s)
Selecting previously unselected package libxslt1.1:amd64.
(Reading database ... 18099 files and directories currently installed.)
Preparing to unpack .../libxslt1.1_1.1.28-2+deb8u1_amd64.deb ...
Unpacking libxslt1.1:amd64 (1.1.28-2+deb8u1) ...
Selecting previously unselected package libffi-dev:amd64.
Preparing to unpack .../libffi-dev_3.1-2+b2_amd64.deb ...
Unpacking libffi-dev:amd64 (3.1-2+b2) ...
Selecting previously unselected package libssl-dev:amd64.
Preparing to unpack .../libssl-dev_1.0.1t-1+deb8u2_amd64.deb ...
Unpacking libssl-dev:amd64 (1.0.1t-1+deb8u2) ...
Selecting previously unselected package libssl-doc.
Preparing to unpack .../libssl-doc_1.0.1t-1+deb8u2_all.deb ...
Unpacking libssl-doc (1.0.1t-1+deb8u2) ...
Selecting previously unselected package libxslt1-dev:amd64.
Preparing to unpack .../libxslt1-dev_1.1.28-2+deb8u1_amd64.deb ...
Unpacking libxslt1-dev:amd64 (1.1.28-2+deb8u1) ...
Setting up libxslt1.1:amd64 (1.1.28-2+deb8u1) ...
Setting up libffi-dev:amd64 (3.1-2+b2) ...
Setting up libssl-dev:amd64 (1.0.1t-1+deb8u2) ...
Setting up libssl-doc (1.0.1t-1+deb8u2) ...
Setting up libxslt1-dev:amd64 (1.1.28-2+deb8u1) ...
Processing triggers for libc-bin (2.19-18+deb8u4) ...
debconf: delaying package configuration, since apt-utils is not installed
```

```
> %%bash
> apt-get install -y -q libxslt-dev libxml2-dev libffi-dev libssl-dev
> pip install -q scrapy

Reading package lists...
Building dependency tree...
Reading state information...
libffi-dev is already the newest version.
libssl-dev is already the newest version.
libxml2-dev is already the newest version.
libxslt1-dev is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```

I've confirmed that I can create a new scrapy project
```
> %%bash
> scrapy startproject tutorial

New Scrapy project 'tutorial', using template directory '/usr/local/lib/python2.7/dist-packages/scrapy/templates/project', created in:
    /content/intro/tutorial

You can start your first spider with:
    cd tutorial
    scrapy genspider example example.com
```