### PR TITLE
Update the stackdriver monitoring notebook to make use of QueryMetadata

### DIFF
--- a/tutorials/Monitoring/Getting started.ipynb
+++ b/tutorials/Monitoring/Getting started.ipynb
@@ -200,7 +200,10 @@
    "source": [
     "### Getting the metadata\n",
     "\n",
-    "The method `labels_as_dataframe()` allows you to look at the labels for the given metric, and the values that exist.\n",
+    "The method `metadata()` returns a `QueryMetadata` object. It contains the following information about the timeseries matching the query:\n",
+    "* resource types\n",
+    "* resource labels and their values\n",
+    "* metric labels and their values\n",
     "\n",
     "This helps you understand the structure of the timeseries data, and makes it easier to modify the query."
    ]
@@ -272,7 +275,7 @@
     }
    ],
    "source": [
-    "metadata_cpu = query_cpu.labels_as_dataframe()\n",
+    "metadata_cpu = query_cpu.metadata().as_dataframe()\n",
     "metadata_cpu.head(5)"
    ]
   },


### PR DESCRIPTION
With the removal of labels_as_dataframe() from the Query class, users
now need to use the QueryMetadata class to look at the metadata.