### PR TITLE
Improve the manual testing instructions.

### DIFF
--- a/.test.sh
+++ b/.test.sh
@@ -31,6 +31,7 @@
 #    docker run -v "$(pwd):/content/notebooks" \
 #      -v "${HOME}:/content/datalab" \
 #      -e "PROJECT_ID=${PROJECT_ID}" \
+#      -e "GOOGLE_APPLICATION_CREDENTIALS=/content/datalab/.config/gcloud/application_default_credentials.json" \
 #      --entrypoint /content/notebooks/.test.sh \
 #      --workdir /content/notebooks \
 #      gcr.io/cloud-datalab/datalab-gateway


### PR DESCRIPTION
This change adds to the instructions for manual testing so that
they specify the GOOGLE_APPLICATION_CREDENTIALS environment variable.