### PR TITLE
Fix a small bug in the BigQuery APIs notebook.

### DIFF
--- a/tutorials/BigQuery/BigQuery APIs.ipynb
+++ b/tutorials/BigQuery/BigQuery APIs.ipynb
@@ -550,7 +550,9 @@
    ],
    "source": [
     "from google.datalab import Context\n",
-    "datasets = bq.Datasets(context = Context('cloud-datalab-samples', None))\n",
+    "ctx = Context.default()\n",
+    "ctx.set_project_id('cloud-datalab-samples')\n",
+    "datasets = bq.Datasets(context = ctx)\n",
     "for ds in datasets:\n",
     "  print ds.name"
    ]


### PR DESCRIPTION
The code here was setting the credentials to `None`, which didn't pan out when
trying to read from BQ.

PTAL @yebrahim @qimingj @brandondutra 