### PR TITLE
Uniquify bucket names in the Storage notebooks.

### DIFF
--- a/tutorials/Storage/Storage APIs.ipynb
+++ b/tutorials/Storage/Storage APIs.ipynb
@@ -51,16 +51,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Bucket: gs://mysampleproject-datalab-samples\n",
-      "Object: gs://mysampleproject-datalab-samples/Hello.txt\n"
+      "Bucket: gs://mysampleproject-datalab-samples-abcde\n",
+      "Object: gs://mysampleproject-datalab-samples-abcde/Hello.txt\n"
      ]
     }
    ],
    "source": [
     "from google.datalab import Context\n",
+    "import random, string\n",
     "\n",
     "project = Context.default().project_id\n",
-    "sample_bucket_name = project + '-datalab-samples'\n",
+    "suffix = ''.join(random.choice(string.lowercase) for _ in range(5))\n",
+    "sample_bucket_name = project + '-datalab-samples-' + suffix\n",
     "sample_bucket_path = 'gs://' + sample_bucket_name\n",
     "sample_bucket_object = sample_bucket_path + '/Hello.txt'\n",
     "\n",
@@ -210,7 +212,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[Google Cloud Storage Object gs://mysampleproject-datalab-samples/sample.txt]\n"
+      "[Google Cloud Storage Object gs://mysampleproject-datalab-samples-abcde/sample.txt]\n"
      ]
     }
    ],

--- a/tutorials/Storage/Storage Commands.ipynb
+++ b/tutorials/Storage/Storage Commands.ipynb
@@ -170,17 +170,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Bucket: gs://mysampleproject-datalab-samples\n",
-      "Object: gs://mysampleproject-datalab-samples/Hello.txt\n"
+      "Bucket: gs://mysampleproject-datalab-samples-abcde\n",
+      "Object: gs://mysampleproject-datalab-samples-abcde/Hello.txt\n"
      ]
     }
    ],
    "source": [
     "# Some code to determine a unique bucket name for the purposes of the sample\n",
     "from google.datalab import Context\n",
+    "import random, string\n",
     "\n",
     "project = Context.default().project_id\n",
-    "sample_bucket_name = project + '-datalab-samples'\n",
+    "suffix = ''.join(random.choice(string.lowercase) for _ in range(5))\n",
+    "sample_bucket_name = project + '-datalab-samples-' + suffix\n",
     "sample_bucket_path = 'gs://' + sample_bucket_name\n",
     "sample_bucket_object = sample_bucket_path + '/Hello.txt'\n",
     "\n",


### PR DESCRIPTION
Currently, we use a fixed bucket name when creating buckets for the two GCS
sample notebooks. This can lead to spurious failures on attempting to delete
the bucket at the end of the notebook(s).

This was causing flakiness with automated tests (where one user was running
both at once), but would also cause conflict in the case of two users running
either notebook at the same time.

The fix is simply to add a likely-unique suffix to the bucket name. While
conflicts can still occur, they're $(26)^5$ times less likely.

PTAL @yebrahim @chmeyers 