### PR TITLE
Update the file test for the `activate` script

### DIFF
--- a/.test.sh
+++ b/.test.sh
@@ -107,7 +107,7 @@ fi
 
 
 # Check if this container has Conda, if so ensure we're in the correct Conda environment.
-if [ -x "$(command -v activate)" ]; then
+if [ -r "$(command -v activate)" ]; then
   source activate "py3env"
   testNotebooks ${DIR}
   source deactivate


### PR DESCRIPTION
Previously, we were checking if the tests should be run inside of the `py3env` conda environment by checking if the `activate` script existed and was executable.

However, the second check is unnecessary, as we do not run `activate` directly, but rather invoke it using `source activate ...`.

... and, in fact, the file permissions of that script have recently changed so that it is not executable any more (so, must be invoked using `source activate ...`).

This change updates the check accordingly to only verify that the file exists and is readable.